### PR TITLE
Fixing the low straight case

### DIFF
--- a/src/PokerHand.js
+++ b/src/PokerHand.js
@@ -37,8 +37,16 @@ PokerHand.prototype.isHandAFlush = function () {
 // It gets transformed into ['I', 'J', 'K', 'L', 'M'] by getOrderedFaces
 // We check if every transformed face char code is equal to the first face char code + the current position
 PokerHand.prototype.isHandAStraight = function () {
-  const first = this.faces[0].charCodeAt(0)
-  return this.faces.every((f, index) => first + index === f.charCodeAt(0));
+  // To handle the low straight case, we need to identify if the hand faces are A, 2, 3, 4, 5 and then transform the Ace in a differrent value
+  const lowStraight = this.faces.join("") === "AJKLM";
+  if (lowStraight) {
+    this.faces[0] = "N";
+  }
+  const first = this.faces[0].charCodeAt(0);
+  return (
+    lowStraight ||
+    this.faces.every((f, index) => first + index === f.charCodeAt(0))
+  );
 }
 
 // We create a dictonnary to count each occurence of every face in the hand

--- a/src/PokerHand.test.js
+++ b/src/PokerHand.test.js
@@ -7,6 +7,7 @@ const onePair = new PokerHand("AS AD KH 8D QS");
 const twoPairs = new PokerHand("AS AD KH KD QS");
 const threeOfAKind = new PokerHand("AS AD AH 8D QS");
 const straight = new PokerHand("AS KS QH JD TS");
+const lowStraight = new PokerHand("AS 2S 3H 4D 5S");
 const flush = new PokerHand("AS 3S KS 8S QS");
 const fullHouse = new PokerHand("AS AD AH QD QS");
 const fourOfAKind = new PokerHand("AS AD AC AH QS");
@@ -23,6 +24,7 @@ test("The faces are correctly extracted and ordered", () => {
 test("isStraight is correctly set", () => {
   expect(hand.isStraight).toBeFalsy();
   expect(straight.isStraight).toBeTruthy();
+  expect(lowStraight.isStraight).toBeTruthy();
   expect(straightFlush.isStraight).toBeTruthy();
 })
 
@@ -38,6 +40,7 @@ test("Rank is set correctly", () => {
   expect(twoPairs.rank).toBe(7);
   expect(threeOfAKind.rank).toBe(6);
   expect(straight.rank).toBe(5);
+  expect(lowStraight.rank).toBe(5);
   expect(flush.rank).toBe(4);
   expect(fullHouse.rank).toBe(3);
   expect(fourOfAKind.rank).toBe(2);
@@ -46,6 +49,8 @@ test("Rank is set correctly", () => {
 
 test("compareWith returns the result correctly", () => {
     expect(onePair.compareWith(highCard)).toBe(1);
+    expect(lowStraight.compareWith(onePair)).toBe(1);
+    expect(lowStraight.compareWith(straight)).toBe(2);
     expect(fullHouse.compareWith(fourOfAKind)).toBe(2);
 
     const sameValueTwoPairs = new PokerHand("AH AC KC KH QD");


### PR DESCRIPTION
### The low straight case ♠️ 

I did not take into account the low straight case (_I don't know a lot about poker I guess 😄_). This case happens when you have a hand with a 2, 3, 4, 5 and Ace. In this case, the Ace should be considered as a low Ace. This means this hand is a considered a straight.

### My approach

1. I first added missing unit tests that tests the low straight case.
2. The I implemented a specific rule to handle the low straight case.
3. And finally I checked that the new unit tests are passing, as well as the other ones to check if my implementation did not create any regression.